### PR TITLE
28apr2026 speedrun

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,6 +556,7 @@
 
         if (elements.markdownCheckbox.checked) {
           activateFormatting();
+          focusOnTextarea();
         }
 
         // Bind event listeners
@@ -566,17 +567,7 @@
           adjustFontSize(1);
         });
 
-        elements.textareaLabel.addEventListener(
-          "click",
-          function focusOnTextarea() {
-            if (elements.tinyMDE !== null) {
-              elements.tinyMDE.e.focus();
-              elements.tinyMDE.setSelection({ col: Infinity, row: Infinity });
-            } else {
-              elements.textarea.focus();
-            }
-          },
-        );
+        elements.textareaLabel.addEventListener("click", focusOnTextarea);
 
         // Open/close Settings window
         elements.settingsButton.addEventListener("click", toggleSettings);
@@ -594,6 +585,15 @@
 
         handleFontSizeChange();
       })();
+
+      function focusOnTextarea() {
+        if (elements.tinyMDE !== null) {
+          elements.tinyMDE.e.focus();
+          elements.tinyMDE.setSelection({ col: Infinity, row: Infinity });
+        } else {
+          elements.textarea.focus();
+        }
+      }
 
       function adjustFontSize(adjustment) {
         if (typeof adjustment === "undefined") return;

--- a/index.html
+++ b/index.html
@@ -144,8 +144,12 @@
       }
 
       @media (hover: hover) and (pointer: fine) {
-        .controls button:hover:not(:disabled),
-        .controls button:hover:not(:disabled) svg {
+        .controls button:hover:not(:disabled) {
+          background-color: oklch(0.95 0 0);
+        }
+
+        .controls button:hover:not(:disabled) span,
+        .controls #settings-button:hover:not(:disabled) {
           background-color: oklch(0.95 0 0);
           color: dodgerblue;
         }
@@ -179,7 +183,8 @@
         color: oklch(0.8 0 0);
       }
 
-      button svg {
+      button svg,
+      button span {
         transition: color 120ms linear;
       }
 

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         }
       }
 
-      #form > label {
+      #form .textarea-label-wrapper {
         grid-area: label;
       }
 
@@ -345,7 +345,9 @@
       role="main"
       style="--font-size: 16px"
     >
-      <label for="textarea" id="textarea-label">Enter text below</label>
+      <div class="textarea-label-wrapper">
+        <label for="textarea" id="textarea-label">Enter text below</label>
+      </div>
       <textarea
         id="textarea"
         name="textarea"

--- a/index.html
+++ b/index.html
@@ -282,17 +282,31 @@
       }
 
       /* Animate icons for #17 */
+      #zoom-out-button .lens,
+      #zoom-in-button .lens,
       #zoom-out-button .minus,
       #zoom-in-button .plus {
         transition: transform 300ms ease-in;
+      }
+
+      #zoom-out-button:focus .lens {
+        transform: scale(1.1);
       }
 
       #zoom-out-button:focus .minus {
         transform: scale(0.6);
       }
 
+      #zoom-in-button:focus .lens {
+        transform: scale(0.9);
+      }
+
       #zoom-in-button:focus .plus {
         transform: scale(1.4);
+      }
+
+      .lens {
+        transform-origin: 11px 11px;
       }
 
       #zoom-in-button .plus {
@@ -323,6 +337,18 @@
       }
 
       @media (hover: hover) and (pointer: fine) {
+        #zoom-out-button:hover:not(:disabled) .lens {
+          transform: scale(1.1);
+        }
+
+        #zoom-out-button:hover:not(:disabled) .minus {
+          transform: scale(0.6);
+        }
+
+        #zoom-in-button:hover:not(:disabled) .lens {
+          transform: scale(0.9);
+        }
+
         #zoom-out-button:hover:not(:disabled) .minus {
           transform: scale(0.6);
         }
@@ -373,8 +399,10 @@
               stroke-linejoin="round"
               class="lucide lucide-zoom-out-icon lucide-zoom-out"
             >
-              <circle cx="11" cy="11" r="8" />
-              <line x1="21" x2="16.65" y1="21" y2="16.65" />
+              <g class="lens">
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" x2="16.65" y1="21" y2="16.65" />
+              </g>
               <line x1="8" x2="14" y1="11" y2="11" class="minus" />
             </svg>
           </button>
@@ -402,8 +430,10 @@
               stroke-linejoin="round"
               class="lucide lucide-zoom-in-icon lucide-zoom-in"
             >
-              <circle cx="11" cy="11" r="8" />
-              <line x1="21" x2="16.65" y1="21" y2="16.65" />
+              <g class="lens">
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" x2="16.65" y1="21" y2="16.65" />
+              </g>
               <g class="plus">
                 <line x1="11" x2="11" y1="8" y2="14" />
                 <line x1="8" x2="14" y1="11" y2="11" />

--- a/index.html
+++ b/index.html
@@ -138,9 +138,14 @@
         border-radius: 20px;
         border: solid 1px oklch(0.8 0 0);
         transition:
+          transform 0 linear,
           background-color 120ms linear,
           color 120ms linear;
         font-size: 16px;
+      }
+
+      button:active {
+        transform: scale(0.95);
       }
 
       @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
This branch introduces a handful of little tweaks:
- Autofocus on TinyMDE editor on page-load (this was broken before)
- Bring more attention to mag lens animation by disabling the color hover on it
- Instead of having label fill up all the empty space next to the controls, shrink it down to its text
- Animate the button in-and-out when clicking it